### PR TITLE
Allow Github Action to push to main branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.BOT_DUCKY_ACCESS_TOKEN_ADMIN_REPO }}
       - uses: actions/setup-node@v2
         with:
           node-version: '16.13.1'


### PR DESCRIPTION
Following article https://dev.to/paulmowat/how-to-resolve-gh006-protected-branch-update-failed-3mgm

Closes [[BUG] deployment issue with RushJS and Github branch protection](https://app.asana.com/0/1200489836971088/1201864308290268/f)