### PR TITLE
additional stories for shadow and width

### DIFF
--- a/common/changes/@ducky/plumage/docs-button-additional-stories-for-shadow-and-width_2022-02-24-10-20.json
+++ b/common/changes/@ducky/plumage/docs-button-additional-stories-for-shadow-and-width_2022-02-24-10-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage",
+      "comment": "Additional documentation for Button component: Storybook stories for shadow and full-width",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@ducky/plumage"
+}

--- a/packages/component-library/src/components/plmg-button/plmg-button.stories.js
+++ b/packages/component-library/src/components/plmg-button/plmg-button.stories.js
@@ -126,6 +126,34 @@ export const AllColors = (args) => {
 };
 AllColors.storyName = 'All colors';
 
+export const AllShadows = (args) => {
+  const htmlContent = `<plmg-button shadow="${false}">No shadow</plmg-button>
+<plmg-button shadow="${true}">With shadow</plmg-button>`;
+
+  const el = document.createElement('div');
+  el.innerHTML = htmlContent;
+  el.style.display = 'flex';
+  el.style.justifyContent = 'space-between';
+  el.style['flex-wrap'] = 'wrap';
+  return el;
+};
+AllShadows.storyName = 'All shadows';
+
+export const AllFullWidth = (args) => {
+  const htmlContent = `<plmg-button full-width="${false}">Fit content</plmg-button>
+<br/>
+<plmg-button full-width="${true}">Full width</plmg-button>`;
+
+  const el = document.createElement('div');
+  el.innerHTML = htmlContent;
+  el.style.display = 'flex';
+  el.style.flexDirection = 'column';
+  el.style.justifyContent = 'space-between';
+  el.style['flex-wrap'] = 'wrap';
+  return el;
+};
+AllFullWidth.storyName = 'All fullWidth';
+
 export const All = (args) => {
   const fullWidthValues = [true, false];
   const shadowValues = [true, false];


### PR DESCRIPTION
Closes [set up a similar layout in Storybook to the one on the overview pages](https://app.asana.com/0/0/1201877428292992/f)

- Add story for shadow
- Add story for fullWidth

These stories will be used in Zeroheight for documentation: [Button overview](https://plumage.ducky.eco/1ef994c2c/p/696fb6-button/b/32e1a2)