### PR TITLE
Better development build perf - es5 only on prod

### DIFF
--- a/common/changes/@ducky/plumage/build-perf-es5-only-on-prod_2022-02-24-10-29.json
+++ b/common/changes/@ducky/plumage/build-perf-es5-only-on-prod_2022-02-24-10-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@ducky/plumage"
+}

--- a/packages/component-library/stencil.config.ts
+++ b/packages/component-library/stencil.config.ts
@@ -6,7 +6,7 @@ export const config: Config = {
   namespace: 'plmg',
   globalStyle: 'src/global.scss',
   plugins: [sass()],
-  buildEs5: true,
+  buildEs5: 'prod',
   outputTargets: [
     reactOutputTarget({
       componentCorePackage: '@ducky/plumage',


### PR DESCRIPTION
Build es5 version only on prod.

- Better build speed during development.
- Get rid of the warning

```
[ WARN  ]  Generating ES5 during development is a very task expensive, initial and incremental builds will be much
           slower. Drop the '--es5' flag and use a modern browser for development.
```