### PR TITLE
React peer dependency range

### DIFF
--- a/common/changes/@ducky/plumage-react/build-react-peer_2022-04-07-09-47.json
+++ b/common/changes/@ducky/plumage-react/build-react-peer_2022-04-07-09-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage-react",
+      "comment": "Support React 17+",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@ducky/plumage-react"
+}

--- a/packages/component-library-react/package.json
+++ b/packages/component-library-react/package.json
@@ -33,7 +33,7 @@
     "@ducky/plumage": "^0.4.0"
   },
   "peerDependencies": {
-    "react": "16.7 - *",
-    "react-dom": "16.7 - *"
+    "react": ">=16.7",
+    "react-dom": ">=16.7"
   }
 }

--- a/packages/component-library-react/package.json
+++ b/packages/component-library-react/package.json
@@ -33,7 +33,7 @@
     "@ducky/plumage": "^0.4.0"
   },
   "peerDependencies": {
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0"
+    "react": "16.7 - *",
+    "react-dom": "16.7 - *"
   }
 }


### PR DESCRIPTION
Change react peer dependency to be from 16.7 to any new major release.
Validated using https://semver.npmjs.com/

### Reviewer checklist:

- Tests for
  - accessibility
  - rendered HTML (spec)
- Storybook stories for all variants
- JSDoc documentation for component
- Update Example app (React, ...)

