### PR TITLE
suggestion: use CSS only to define icon's size

### DIFF
--- a/packages/component-library/src/components/plmg-error-message/plmg-error-message.scss
+++ b/packages/component-library/src/components/plmg-error-message/plmg-error-message.scss
@@ -31,6 +31,10 @@
     }
   }
 
+  plmg-svg-icon {
+    font-size: tokens.$plmg-font-size-x0-875;
+  }
+
   span {
     margin-left: tokens.$plmg-spacing-x0-25;
     font-size: inherit;

--- a/packages/component-library/src/components/plmg-error-message/plmg-error-message.tsx
+++ b/packages/component-library/src/components/plmg-error-message/plmg-error-message.tsx
@@ -3,7 +3,6 @@ import {
   PlmgErrorMessageSize,
   isPlmgErrorMessageSize,
 } from './plmg-error-message.types';
-import { plmgFontSizeX0875 } from '@ducky/plumage-tokens';
 
 @Component({
   tag: 'plmg-error-message',
@@ -44,11 +43,9 @@ export class ErrorMessage {
       'error-message-wrapper': true,
     };
 
-    const iconSize = this.size === 'medium' ? plmgFontSizeX0875 : undefined;
-
     return (
       <div class={errorClasses}>
-        <plmg-svg-icon icon="warningAmber" size={iconSize} />
+        <plmg-svg-icon icon="warningAmber" />
         <span>{this.message}</span>
       </div>
     );


### PR DESCRIPTION
A suggested improvement: use CSS only to define icon's size

- less code
- no token import in JS file

