### PR TITLE
fix(story)add missing prop value

### DIFF
--- a/common/changes/@ducky/plumage-react/fix-textinput_2022-08-05-09-08.json
+++ b/common/changes/@ducky/plumage-react/fix-textinput_2022-08-05-09-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@ducky/plumage-react"
+}

--- a/common/changes/@ducky/plumage/fix-textinput_2022-08-05-09-08.json
+++ b/common/changes/@ducky/plumage/fix-textinput_2022-08-05-09-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage",
+      "comment": "fix(story):add missing prop value to storybook example",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@ducky/plumage"
+}

--- a/packages/component-library/src/components/plmg-text-input/plmg-text-input.stories.js
+++ b/packages/component-library/src/components/plmg-text-input/plmg-text-input.stories.js
@@ -93,7 +93,7 @@ Tip.storyName = 'Tip Text';
 Tip.args = {
   label: 'Tip Text',
   ['show-label']: false,
-  tip: '',
+  tip: 'Tip Text',
 };
 
 export const Required = Template.bind({});


### PR DESCRIPTION
Closes [bug](https://app.asana.com/0/1198920871936085/1202719879174364)

### Summary of changes included in this PR

- just adds a missing value to tip prop on storybook (tip example)
