### PR TITLE
fix(plmg-page-container): Account for header height

### DIFF
--- a/common/changes/@ducky/plumage/SF-plmg-page-container-height_2022-08-15-17-43.json
+++ b/common/changes/@ducky/plumage/SF-plmg-page-container-height_2022-08-15-17-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage",
+      "comment": "fix(page-container): Account for header height in page container height",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@ducky/plumage"
+}

--- a/packages/component-library/src/components/plmg-page-container/plmg-page-container.scss
+++ b/packages/component-library/src/components/plmg-page-container/plmg-page-container.scss
@@ -9,7 +9,7 @@
   .plmg-content {
     display: block;
     position: absolute;
-    height: 100%;
+    height: calc(100% - 99px); //Height of the header
     top: 99px; // Height of the header
     left: 0;
     right: 0;


### PR DESCRIPTION
<!-- List all User Stories / Bug / Task addressed in this PR. Add one line per Asana link. -->

Closes [this task](https://app.asana.com/0/1200489836971088/1202807793074107/f)

### Summary of changes included in this PR

Henlo frenz, we are using the `plmg-page-container` component in the admin panel, and we are getting this scrollbar appearing because the page content height is set to 100%, but I believe we want to account for the header height here? We already account for it when we set the `top` offset of the content, just not the content `height`. If you have a better solution I'm happy to do that instead ^_^ I have an example here, note the vertical scrollbar:

Before:
![Screen Shot 2022-08-15 at 1 18 38 PM](https://user-images.githubusercontent.com/9171326/184685861-9843dc62-161d-4b38-93f4-45a1c1e6b75b.png)

After:
![Screen Shot 2022-08-15 at 1 19 11 PM](https://user-images.githubusercontent.com/9171326/184685868-5b51f3d9-09d7-44cc-8167-5d666733de3b.png)


### Reviewer checklist:

- Tests for
  - accessibility
  - rendered HTML (spec)
- Storybook stories for all variants
- JSDoc documentation for component
- Update Example app (React, ...)


