### PR TITLE
Fix/text input missing value attribute

### DIFF
--- a/common/changes/@ducky/plumage/fix-textInputMissingValueAttribute_2022-09-12-06-58.json
+++ b/common/changes/@ducky/plumage/fix-textInputMissingValueAttribute_2022-09-12-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage",
+      "comment": "adds value attribute",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@ducky/plumage"
+}

--- a/packages/component-library/src/components.d.ts
+++ b/packages/component-library/src/components.d.ts
@@ -371,7 +371,7 @@ export namespace Components {
          */
         "tip": string;
         /**
-          * Control the form's value  Allowed values: - Any string  Sets the value of the text input
+          * Control text input's value  Allowed values: - Any string  Set the value of the text input
          */
         "value": string;
     }
@@ -943,7 +943,7 @@ declare namespace LocalJSX {
          */
         "tip"?: string;
         /**
-          * Control the form's value  Allowed values: - Any string  Sets the value of the text input
+          * Control text input's value  Allowed values: - Any string  Set the value of the text input
          */
         "value"?: string;
     }

--- a/packages/component-library/src/components.d.ts
+++ b/packages/component-library/src/components.d.ts
@@ -370,6 +370,10 @@ export namespace Components {
           * Define tip  Allowed value: any string  Displays a tip message
          */
         "tip": string;
+        /**
+          * Control the form's value  Allowed values: - Any string  Sets the value of the text input
+         */
+        "value": string;
     }
     interface PlmgTooltip {
         /**
@@ -938,6 +942,10 @@ declare namespace LocalJSX {
           * Define tip  Allowed value: any string  Displays a tip message
          */
         "tip"?: string;
+        /**
+          * Control the form's value  Allowed values: - Any string  Sets the value of the text input
+         */
+        "value"?: string;
     }
     interface PlmgTooltip {
         /**

--- a/packages/component-library/src/components/plmg-text-input/plmg-text-input.stories.js
+++ b/packages/component-library/src/components/plmg-text-input/plmg-text-input.stories.js
@@ -25,6 +25,9 @@ export default {
     tip: {
       control: { type: 'text' },
     },
+    value: {
+      control: { type: 'text' },
+    },
   },
 };
 
@@ -35,6 +38,7 @@ const PROPS = [
   'required',
   'size',
   'tip',
+  'value',
 ];
 
 const EVENTS = [];
@@ -54,6 +58,7 @@ Primary.args = {
   ['error-message']: '',
   ['show-label']: false,
   required: false,
+  value: '',
 };
 
 export const AllSizes = (args) => {

--- a/packages/component-library/src/components/plmg-text-input/plmg-text-input.tsx
+++ b/packages/component-library/src/components/plmg-text-input/plmg-text-input.tsx
@@ -18,7 +18,6 @@ import {
   shadow: false,
 })
 export class TextInput {
-  @State() value: string;
   /**
    * Define error message
    *
@@ -110,15 +109,39 @@ export class TextInput {
     if (newValue && typeof newValue !== 'string')
       throw new Error('tip text must be a string');
   }
+  /**
+   * Control text input's value
+   *
+   * Allowed values:
+   * - Any string
+   *
+   * Set the value of the text input
+   */
+  @Prop() value: string;
+  @Watch('value')
+  validateValue(newValue: string) {
+    console.log('validate value', newValue);
 
+    if (typeof newValue !== 'string') throw new Error('value must be a string');
+  }
+  @Watch('value')
+  setValue(newValue: string) {
+    this.internalValue = newValue;
+  }
+
+  @State() internalValue: string;
   private handleInputChange(ev) {
-    this.value = ev.target.value;
-    this.valueUpdated.emit({ value: this.value });
+    this.internalValue = ev.target.value;
+    this.valueUpdated.emit({ value: this.internalValue });
   }
   /**
    * Event emitted when value changed
    */
   @Event() valueUpdated: EventEmitter;
+
+  connectedCallback() {
+    this.internalValue = this.value;
+  }
 
   componentWillLoad() {
     this.validateSize(this.size);
@@ -154,7 +177,7 @@ export class TextInput {
             name={this.label}
             required={this.required}
             type={'text'}
-            value={this.value}
+            value={this.internalValue}
             onInput={(ev) => this.handleInputChange(ev)}
           />
         </div>

--- a/packages/component-library/src/components/plmg-text-input/plmg-text-input.tsx
+++ b/packages/component-library/src/components/plmg-text-input/plmg-text-input.tsx
@@ -120,8 +120,6 @@ export class TextInput {
   @Prop() value: string;
   @Watch('value')
   validateValue(newValue: string) {
-    console.log('validate value', newValue);
-
     if (typeof newValue !== 'string') throw new Error('value must be a string');
   }
   @Watch('value')

--- a/packages/component-library/src/components/plmg-text-input/test/plmg-text-input.e2e.ts
+++ b/packages/component-library/src/components/plmg-text-input/test/plmg-text-input.e2e.ts
@@ -133,3 +133,34 @@ describe('plmg-text-input', () => {
     expect(results.violations).toHaveLength(0);
   });
 });
+
+describe('value attribute', () => {
+  it('sets the text input value', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<plmg-text-input label="text-input" value="your value"></plmg-text-input>'
+    );
+    const component = await page.find('plmg-text-input');
+    const inputFieldElement = await page.find('input[type="text"]');
+    expect(await component.getProperty('value')).toEqual('your value');
+    expect(await inputFieldElement.getProperty('value')).toEqual('your value');
+  });
+  it('is updated after user input', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<plmg-text-input label="text-input" value="initial text"></plmg-text-input>'
+    );
+    const component = await page.find('plmg-text-input');
+    const inputFieldElement = await page.find('input[type="text"]');
+    expect(await component.getProperty('value')).toEqual('initial text');
+    expect(await inputFieldElement.getProperty('value')).toEqual(
+      'initial text'
+    );
+    await inputFieldElement.type(` additional text`);
+    await inputFieldElement.press('Enter');
+    await page.waitForChanges();
+    expect(await inputFieldElement.getProperty('value')).toEqual(
+      'initial text additional text'
+    );
+  });
+});


### PR DESCRIPTION
Closes [BUG TextInput - Missing Value Prop](https://app.asana.com/0/1198920871936085/1202916016776157/f)

### Summary of changes included in this PR

- Adds a value attribute
- Renames value used internally in the component to internalValue
- Updates stories with value
- Adds tests for value attribute
- Updates docs with value prop
- No changes made to React example app in this update. 

### Reviewer checklist:

- Tests for
  - accessibility
  - rendered HTML (spec)
- Storybook stories for all variants
- JSDoc documentation for component
- Update Example app (React, ...)


