### PR TITLE
Feat/text input readonly disabled

### DIFF
--- a/common/changes/@ducky/plumage/feat-textInputReadonlyDisabled_2022-09-15-09-24.json
+++ b/common/changes/@ducky/plumage/feat-textInputReadonlyDisabled_2022-09-15-09-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage",
+      "comment": "TextInput: add disabled and readonly attributes",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@ducky/plumage"
+}

--- a/packages/component-library/src/components.d.ts
+++ b/packages/component-library/src/components.d.ts
@@ -347,6 +347,10 @@ export namespace Components {
     }
     interface PlmgTextInput {
         /**
+          * Define disabled  Allowed value: boolean  Disables text input
+         */
+        "disabled": boolean;
+        /**
           * Define error message  Allowed value: any string  Sets error style and error message
          */
         "errorMessage": string;
@@ -354,6 +358,10 @@ export namespace Components {
           * Define a label name for the input field.  Allowed values: - Any string  A unique label name for each element in a form is required for accessibility
          */
         "label": string;
+        /**
+          * Define readonly  Allowed value: boolean  Makes text input read only
+         */
+        "readOnly": boolean;
         /**
           * Define if an input is required.  Allowed values: - true - false  Default: false
          */
@@ -371,7 +379,7 @@ export namespace Components {
          */
         "tip": string;
         /**
-          * Control text input's value  Allowed values: - Any string  Set the value of the text input
+          * Control the text input's value  Allowed values: - Any string  Sets the value of the text input
          */
         "value": string;
     }
@@ -915,6 +923,10 @@ declare namespace LocalJSX {
     }
     interface PlmgTextInput {
         /**
+          * Define disabled  Allowed value: boolean  Disables text input
+         */
+        "disabled"?: boolean;
+        /**
           * Define error message  Allowed value: any string  Sets error style and error message
          */
         "errorMessage"?: string;
@@ -926,6 +938,10 @@ declare namespace LocalJSX {
           * Event emitted when value changed
          */
         "onValueUpdated"?: (event: PlmgTextInputCustomEvent<any>) => void;
+        /**
+          * Define readonly  Allowed value: boolean  Makes text input read only
+         */
+        "readOnly"?: boolean;
         /**
           * Define if an input is required.  Allowed values: - true - false  Default: false
          */
@@ -943,7 +959,7 @@ declare namespace LocalJSX {
          */
         "tip"?: string;
         /**
-          * Control text input's value  Allowed values: - Any string  Set the value of the text input
+          * Control the text input's value  Allowed values: - Any string  Sets the value of the text input
          */
         "value"?: string;
     }

--- a/packages/component-library/src/components/plmg-text-input/plmg-text-input.scss
+++ b/packages/component-library/src/components/plmg-text-input/plmg-text-input.scss
@@ -118,6 +118,10 @@
     color: tokens.$plmg-color-text-neutral;
     border-radius: tokens.$plmg-border-radius-s;
     background-color: tokens.$plmg-color-background-neutral;
+    &:disabled,
+    &:read-only {
+      background-color: tokens.$plmg-color-background-neutral-medium;
+    }
     &.error {
       border: tokens.$plmg-border-width-m solid
         tokens.$plmg-color-border-danger-strong;
@@ -133,7 +137,7 @@
       padding: tokens.$plmg-spacing-x1 tokens.$plmg-spacing-x1-5;
     }
     @include reset-states;
-    &:hover:not(:focus) {
+    &:hover:not(:focus):not(:disabled):not(:read-only) {
       background-color: tokens.$plmg-color-background-neutral-hover;
     }
     &:focus-visible {

--- a/packages/component-library/src/components/plmg-text-input/plmg-text-input.stories.js
+++ b/packages/component-library/src/components/plmg-text-input/plmg-text-input.stories.js
@@ -6,6 +6,11 @@ export default {
   parameters: {},
   decorators: [],
   argTypes: {
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
     ['error-message']: {
       control: { type: 'text' },
     },
@@ -14,6 +19,11 @@ export default {
     },
     ['show-label']: {
       control: { type: 'boolean' },
+    },
+    ['read-only']: {
+      control: {
+        type: 'boolean',
+      },
     },
     required: {
       control: { type: 'boolean' },
@@ -32,9 +42,11 @@ export default {
 };
 
 const PROPS = [
+  'disabled',
   'error-message',
   'show-label',
   'label',
+  'read-only',
   'required',
   'size',
   'tip',
@@ -78,6 +90,21 @@ export const AllSizes = (args) => {
   return el;
 };
 AllSizes.storyName = 'All Sizes';
+
+export const disabled = Template.bind({});
+disabled.storyName = 'Disabled';
+disabled.args = {
+  label: 'Disabled',
+  disabled: true,
+};
+
+export const readOnly = Template.bind({});
+readOnly.storyName = 'Read Only';
+readOnly.args = {
+  label: 'Read Only',
+  ['read-only']: true,
+  value: 'Cannot be edited, but can be copied',
+};
 
 export const showLabel = Template.bind({});
 showLabel.storyName = 'Label';

--- a/packages/component-library/src/components/plmg-text-input/plmg-text-input.tsx
+++ b/packages/component-library/src/components/plmg-text-input/plmg-text-input.tsx
@@ -19,6 +19,19 @@ import {
 })
 export class TextInput {
   /**
+   * Define disabled
+   *
+   * Allowed value: boolean
+   *
+   * Disables text input
+   */
+  @Prop() disabled: boolean = false;
+  @Watch('disabled')
+  validateDisabled(newValue: boolean) {
+    if (newValue && typeof newValue !== 'boolean')
+      throw new Error('disabled must be boolean');
+  }
+  /**
    * Define error message
    *
    * Allowed value: any string
@@ -59,6 +72,19 @@ export class TextInput {
   validateShowLabel(newValue: boolean) {
     if (newValue && typeof newValue !== 'boolean')
       throw new Error('show label must be boolean');
+  }
+  /**
+   * Define readonly
+   *
+   * Allowed value: boolean
+   *
+   * Makes text input read only
+   */
+  @Prop() readOnly: boolean = false;
+  @Watch('readOnly')
+  validateReadOnly(newValue: boolean) {
+    if (newValue && typeof newValue !== 'boolean')
+      throw new Error('readOnly must be boolean');
   }
   /**
    * Define if an input is required.
@@ -110,16 +136,18 @@ export class TextInput {
       throw new Error('tip text must be a string');
   }
   /**
-   * Control text input's value
+   * Control the text input's value
    *
    * Allowed values:
    * - Any string
    *
-   * Set the value of the text input
+   * Sets the value of the text input
    */
   @Prop() value: string;
   @Watch('value')
   validateValue(newValue: string) {
+    console.log('validate value', newValue);
+
     if (typeof newValue !== 'string') throw new Error('value must be a string');
   }
   @Watch('value')
@@ -170,11 +198,13 @@ export class TextInput {
         </label>
         <div class={'plmg-text-input-field-wrapper'} tabIndex={0}>
           <input
+            disabled={this.disabled}
             class={inputClasses}
             id={this.labelToId()}
             name={this.label}
             required={this.required}
             type={'text'}
+            readonly={this.readOnly}
             value={this.internalValue}
             onInput={(ev) => this.handleInputChange(ev)}
           />

--- a/packages/component-library/src/components/plmg-text-input/plmg-text-input.tsx
+++ b/packages/component-library/src/components/plmg-text-input/plmg-text-input.tsx
@@ -146,8 +146,6 @@ export class TextInput {
   @Prop() value: string;
   @Watch('value')
   validateValue(newValue: string) {
-    console.log('validate value', newValue);
-
     if (typeof newValue !== 'string') throw new Error('value must be a string');
   }
   @Watch('value')

--- a/packages/component-library/src/components/plmg-text-input/readme.md
+++ b/packages/component-library/src/components/plmg-text-input/readme.md
@@ -9,13 +9,15 @@
 
 | Property             | Attribute       | Description                                                                                                                                          | Type                  | Default     |
 | -------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | ----------- |
+| `disabled`           | `disabled`      | Define disabled  Allowed value: boolean  Disables text input                                                                                         | `boolean`             | `false`     |
 | `errorMessage`       | `error-message` | Define error message  Allowed value: any string  Sets error style and error message                                                                  | `string`              | `undefined` |
 | `label` _(required)_ | `label`         | Define a label name for the input field.  Allowed values: - Any string  A unique label name for each element in a form is required for accessibility | `string`              | `undefined` |
+| `readOnly`           | `read-only`     | Define readonly  Allowed value: boolean  Makes text input read only                                                                                  | `boolean`             | `false`     |
 | `required`           | `required`      | Define if an input is required.  Allowed values: - true - false  Default: false                                                                      | `boolean`             | `false`     |
 | `showLabel`          | `show-label`    | Define if the label is shown  Allowed values: - true - false  Default: true                                                                          | `boolean`             | `true`      |
 | `size`               | `size`          |  Define text input's size  Allowed values:   - medium   - large  Default: medium                                                                     | `"large" \| "medium"` | `'medium'`  |
 | `tip`                | `tip`           | Define tip  Allowed value: any string  Displays a tip message                                                                                        | `string`              | `undefined` |
-| `value`              | `value`         | Control text input's value  Allowed values: - Any string  Set the value of the text input                                                            | `string`              | `undefined` |
+| `value`              | `value`         | Control the text input's value  Allowed values: - Any string  Sets the value of the text input                                                       | `string`              | `undefined` |
 
 
 ## Events

--- a/packages/component-library/src/components/plmg-text-input/test/plmg-text-input.e2e.ts
+++ b/packages/component-library/src/components/plmg-text-input/test/plmg-text-input.e2e.ts
@@ -132,6 +132,56 @@ describe('plmg-text-input', () => {
 
     expect(results.violations).toHaveLength(0);
   });
+  it('disabled is accessible', async () => {
+    const page = await newE2EPage();
+
+    const isDisabled = [true, false];
+    let htmlContent = '';
+    isDisabled.forEach((disabled) => {
+      htmlContent += `
+    <plmg-text-input label='disabled ${disabled}' disabled={${disabled}}>
+    </plmg-text-input>
+    `;
+    });
+
+    await page.setContent('<main>' + htmlContent + '</main>');
+
+    const results = await new AxePuppeteer(page as unknown as Page)
+      .disableRules([
+        'document-title',
+        'html-has-lang',
+        'landmark-one-main',
+        'page-has-heading-one',
+      ])
+      .analyze();
+
+    expect(results.violations).toHaveLength(0);
+  });
+  it('readonly is accessible', async () => {
+    const page = await newE2EPage();
+
+    const isReadonly = [true, false];
+    let htmlContent = '';
+    isReadonly.forEach((readonly) => {
+      htmlContent += `
+    <plmg-text-input label='readonly ${readonly}' readonly={${readonly}}>
+    </plmg-text-input>
+    `;
+    });
+
+    await page.setContent('<main>' + htmlContent + '</main>');
+
+    const results = await new AxePuppeteer(page as unknown as Page)
+      .disableRules([
+        'document-title',
+        'html-has-lang',
+        'landmark-one-main',
+        'page-has-heading-one',
+      ])
+      .analyze();
+
+    expect(results.violations).toHaveLength(0);
+  });
 });
 
 describe('value attribute', () => {


### PR DESCRIPTION
Closes [DEVELOP: [UPDATE] Text input](https://app.asana.com/0/1198920871936085/1202956480073056/f)

### Summary of changes included in this PR
- Adds disabled and readonly attributes to component and adds:
  - tests for accessibility
  - story book examples
  - updated docs
  - updated changelog

### Unchanged
- Does not update react example app

### Reviewer checklist:

- Tests for
  - accessibility
  - rendered HTML (spec)
- Storybook stories for all variants
- JSDoc documentation for component
- Update Example app (React, ...)

