### PR TITLE
react release above 1

### DIFF
--- a/common/changes/@ducky/plumage-react/build-react-release-above-1_2022-09-20-12-14.json
+++ b/common/changes/@ducky/plumage-react/build-react-release-above-1_2022-09-20-12-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage-react",
+      "comment": "Bump to version 1.0.0",
+      "type": "major"
+    }
+  ],
+  "packageName": "@ducky/plumage-react"
+}

--- a/packages/component-library-react/README.md
+++ b/packages/component-library-react/README.md
@@ -1,4 +1,4 @@
-# Plumage + React
+# Plumage ♥ React
 This is our React library for Plumage.
 
 This package exposes Ducky's design system as React components.


### PR DESCRIPTION


### Summary of changes included in this PR

- Force the bump of the react library to version 1.0.0

 The goal is to later be able to bump dependency "Plumage" automatically

### Reviewer checklist:

- Tests for
  - accessibility
  - rendered HTML (spec)
- Storybook stories for all variants
- JSDoc documentation for component
- Update Example app (React, ...)

