### PR TITLE
Tab: Fix focus trap

### DIFF
--- a/common/changes/@ducky/plumage/fix-tabFocus_2022-09-21-09-30.json
+++ b/common/changes/@ducky/plumage/fix-tabFocus_2022-09-21-09-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage",
+      "comment": "Tab component: removes focus trap",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@ducky/plumage"
+}

--- a/examples/react-app/src/index.tsx
+++ b/examples/react-app/src/index.tsx
@@ -131,7 +131,6 @@ ReactDOM.render(
       <PlmgSvgIcon icon={'home'} size={'6em'} />
       PlmgSvgIcon home
       <br />
-      <Dropdown />
       <PlmgCard
         headerText="Header Text"
         topActionIcon={'home'}

--- a/examples/react-app/src/index.tsx
+++ b/examples/react-app/src/index.tsx
@@ -131,6 +131,7 @@ ReactDOM.render(
       <PlmgSvgIcon icon={'home'} size={'6em'} />
       PlmgSvgIcon home
       <br />
+      <Dropdown />
       <PlmgCard
         headerText="Header Text"
         topActionIcon={'home'}

--- a/packages/component-library/src/components/plmg-tabs/plmg-tabs.tsx
+++ b/packages/component-library/src/components/plmg-tabs/plmg-tabs.tsx
@@ -105,8 +105,8 @@ export class Tabs {
     );
   }
 
-  private hasIcon(icon: string) {
-    return icon && (icon as string) !== '';
+  private hasIcon(icon?: string) {
+    return Boolean(icon);
   }
 
   private activateTab(tabIndex: number) {

--- a/packages/component-library/src/components/plmg-tabs/plmg-tabs.tsx
+++ b/packages/component-library/src/components/plmg-tabs/plmg-tabs.tsx
@@ -128,11 +128,13 @@ export class Tabs {
   }
 
   private blurTabButton(tabIndex: number) {
-    const buttons = document.getElementsByClassName(
+    const getButtons = document.getElementsByClassName(
       'plmg-tab-button'
     ) as HTMLCollectionOf<HTMLButtonElement>;
-    if (document.activeElement === buttons.item(tabIndex)) {
-      buttons.item(tabIndex).blur();
+
+    const buttons = Array.from(getButtons);
+    if (buttons && buttons[tabIndex].hasAttribute('tabindex')) {
+      buttons[tabIndex].blur();
     }
   }
 }

--- a/packages/component-library/src/components/plmg-tabs/plmg-tabs.tsx
+++ b/packages/component-library/src/components/plmg-tabs/plmg-tabs.tsx
@@ -131,10 +131,8 @@ export class Tabs {
     const buttons = this.el.getElementsByClassName(
       'plmg-tab-button'
     ) as HTMLCollectionOf<HTMLButtonElement>;
-
-    const buttons = Array.from(getButtons);
-    if (buttons && buttons[tabIndex].hasAttribute('tabindex')) {
-      buttons[tabIndex].blur();
+    if (document.activeElement === buttons.item(tabIndex)) {
+      buttons.item(tabIndex).blur();
     }
   }
 }

--- a/packages/component-library/src/components/plmg-tabs/plmg-tabs.tsx
+++ b/packages/component-library/src/components/plmg-tabs/plmg-tabs.tsx
@@ -39,12 +39,16 @@ export class Tabs {
     event.stopPropagation();
     if (event.key === 'Enter') {
       this.openTab(tabIndex);
+      return this.blurTabButton(tabIndex);
+    }
+    if (event.key === 'Tab') {
+      return this.blurTabButton(tabIndex);
     }
     if (event.key === 'ArrowLeft') {
-      if (tabIndex > 0) this.openTab(tabIndex - 1);
+      if (tabIndex > 0) return this.openTab(tabIndex - 1);
     }
     if (event.key === 'ArrowRight') {
-      if (tabIndex < this.tabs.length - 1) this.openTab(tabIndex + 1);
+      if (tabIndex < this.tabs.length - 1) return this.openTab(tabIndex + 1);
     }
   }
 
@@ -101,11 +105,11 @@ export class Tabs {
     );
   }
 
-  private hasIcon(icon) {
+  private hasIcon(icon: string) {
     return icon && (icon as string) !== '';
   }
 
-  private activateTab(tabIndex) {
+  private activateTab(tabIndex: number) {
     const disabledTab = this.tabs[tabIndex].disabled;
 
     this.tabs = this.tabs.map((tab, i) => {
@@ -120,6 +124,15 @@ export class Tabs {
     });
     if (!disabledTab) {
       this.onChange.emit({ tabId: tabIndex });
+    }
+  }
+
+  private blurTabButton(tabIndex: number) {
+    const buttons = document.getElementsByClassName(
+      'plmg-tab-button'
+    ) as HTMLCollectionOf<HTMLButtonElement>;
+    if (document.activeElement === buttons.item(tabIndex)) {
+      buttons.item(tabIndex).blur();
     }
   }
 }

--- a/packages/component-library/src/components/plmg-tabs/plmg-tabs.tsx
+++ b/packages/component-library/src/components/plmg-tabs/plmg-tabs.tsx
@@ -115,7 +115,7 @@ export class Tabs {
     this.tabs = this.tabs.map((tab, i) => {
       if (!disabledTab) tab.active = i === tabIndex;
       if (i === tabIndex) {
-        const buttons = document.getElementsByClassName(
+        const buttons = this.el.getElementsByClassName(
           'plmg-tab-button'
         ) as HTMLCollectionOf<HTMLButtonElement>;
         buttons.item(i).focus();
@@ -128,13 +128,11 @@ export class Tabs {
   }
 
   private blurTabButton(tabIndex: number) {
-    const getButtons = document.getElementsByClassName(
+    const buttons = this.el.getElementsByClassName(
       'plmg-tab-button'
     ) as HTMLCollectionOf<HTMLButtonElement>;
-
-    const buttons = Array.from(getButtons);
-    if (buttons && buttons[tabIndex].hasAttribute('tabindex')) {
-      buttons[tabIndex].blur();
+    if (document.activeElement === buttons.item(tabIndex)) {
+      buttons.item(tabIndex).blur();
     }
   }
 }


### PR DESCRIPTION
### Summary of changes included in this PR

- Removes focus trap by setting blur on enter/tab keyboard input replicating accessible behaviour [seen here](https://lion-web.netlify.app/components/tabs/overview/#tabs-overview)
- Adds some missing returns statements and typescript 
- Removes a missing import bug from react app

### Reviewer checklist:

- Tests for
  - accessibility
  - rendered HTML (spec)
- Storybook stories for all variants
- JSDoc documentation for component
- Update Example app (React, ...)

