### PR TITLE
fix(react-example):remove non-existent component

### DIFF
--- a/examples/react-app/src/index.tsx
+++ b/examples/react-app/src/index.tsx
@@ -131,7 +131,6 @@ ReactDOM.render(
       <PlmgSvgIcon icon={'home'} size={'6em'} />
       PlmgSvgIcon home
       <br />
-      <Dropdown />
       <PlmgCard
         headerText="Header Text"
         topActionIcon={'home'}


### PR DESCRIPTION
Fixes a bug in the React Example App to remove a nonexistent component: 'Dropdown'
I believe no change log update is required for this change? 