### PR TITLE
Fix/slider resize observer

### DIFF
--- a/common/changes/@ducky/plumage/fix-sliderResizeObserver_2022-09-24-07-16.json
+++ b/common/changes/@ducky/plumage/fix-sliderResizeObserver_2022-09-24-07-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage",
+      "comment": "Fixes slider component resize handler",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@ducky/plumage"
+}


### PR DESCRIPTION
Closes [[BUG] Plmg-Slider: Resize Handler](https://app.asana.com/0/1198920871936085/1203044594185213/f)

### Summary of changes included in this PR
- Replaces window-scoped resize event listener with a component-scoped event listener. 
- Adds changelog.

### Reviewer checklist:

- Tests for
  - accessibility
  - rendered HTML (spec)
- Storybook stories for all variants
- JSDoc documentation for component
- Update Example app (React, ...)

