### PR TITLE
Fix/header zindex too low

### DIFF
--- a/common/changes/@ducky/plumage/fix-HeaderZindexTooLow_2022-10-04-03-54.json
+++ b/common/changes/@ducky/plumage/fix-HeaderZindexTooLow_2022-10-04-03-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage",
+      "comment": "Fixes low z-index bug on header",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@ducky/plumage"
+}

--- a/packages/component-library/src/components/plmg-header/plmg-header.scss
+++ b/packages/component-library/src/components/plmg-header/plmg-header.scss
@@ -12,7 +12,7 @@
   align-items: center;
   box-shadow: tokens.$plmg-shadow-s;
   background: tokens.$plmg-color-background-neutral;
-  z-index: 1;
+  z-index: 9999;
 
   // Same height as .plmg-sidebar-top
   height: 99px - 2 * tokens.$plmg-spacing-x1-5;


### PR DESCRIPTION
Closes[BUG Plmg-Header z index too low](https://app.asana.com/0/1200489836971088/1202856087042824/f)

### Summary of changes included in this PR
- Increases header z-index to 9999
- Changelog docs.

### Reviewer checklist:

- Tests for
  - accessibility
  - rendered HTML (spec)
- Storybook stories for all variants
- JSDoc documentation for component
- Update Example app (React, ...)

