### PR TITLE
Fix/drop down focus border

### DIFF
--- a/common/changes/@ducky/plumage/fix-dropDownFocusBorder_2022-10-04-05-31.json
+++ b/common/changes/@ducky/plumage/fix-dropDownFocusBorder_2022-10-04-05-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage",
+      "comment": "Adds focus visible ring & border radius prop",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@ducky/plumage"
+}

--- a/packages/component-library/src/components.d.ts
+++ b/packages/component-library/src/components.d.ts
@@ -122,6 +122,10 @@ export namespace Components {
          */
         "align": PlmgDropdownAlignments;
         /**
+          * Set the border radius of trigger element.  Allow values:  - any valid css border radius value  Default: none
+         */
+        "borderRadius": string;
+        /**
           * Disable document scoped event listeners.  Does not disable the click event on the trigger element or keyboard events.  Allowed values:   - true   - false  Default: false
          */
         "disableListeners": boolean;
@@ -791,6 +795,10 @@ declare namespace LocalJSX {
           * Define the alignment of the dropdown menu.  Allowed values:   - left   - right  Default: left
          */
         "align"?: PlmgDropdownAlignments;
+        /**
+          * Set the border radius of trigger element.  Allow values:  - any valid css border radius value  Default: none
+         */
+        "borderRadius"?: string;
         /**
           * Disable document scoped event listeners.  Does not disable the click event on the trigger element or keyboard events.  Allowed values:   - true   - false  Default: false
          */

--- a/packages/component-library/src/components/plmg-dropdown/plmg-dropdown.scss
+++ b/packages/component-library/src/components/plmg-dropdown/plmg-dropdown.scss
@@ -6,6 +6,13 @@
 .plmg-dropdown {
   position: relative;
   display: inline-block;
+
+  &:focus-visible {
+    background: tokens.$plmg-color-background-neutral-medium;
+    outline: tokens.$plmg-border-width-l solid
+      tokens.$plmg-color-border-standout;
+    z-index: 999;
+  }
 }
 
 .plmg-dropdown-menu {

--- a/packages/component-library/src/components/plmg-dropdown/plmg-dropdown.stories.js
+++ b/packages/component-library/src/components/plmg-dropdown/plmg-dropdown.stories.js
@@ -5,6 +5,9 @@ export default {
   parameters: {},
   decorators: [],
   argTypes: {
+    ['border-radius']: {
+      control: { type: 'text' },
+    },
     ['trigger']: { control: { type: 'text' } },
     ['menu']: { control: { type: 'text' } },
     ['disable-listeners']: {
@@ -18,7 +21,7 @@ export default {
   },
 };
 
-const PROPS = ['align', 'disable-listeners'];
+const PROPS = ['align', 'border-radius', 'disable-listeners'];
 const EVENTS = [];
 const SLOTS = ['trigger', 'menu'];
 
@@ -34,6 +37,7 @@ export const Primary = Template.bind({});
 Primary.storyName = 'Dropdown';
 Primary.args = {
   align: 'left',
+  ['border-radius']: '50%',
   ['disable-listeners']: false,
   ['trigger']: `<plmg-avatar style="width: 48px" slot="trigger" size="medium"></plmg-avatar>`,
   ['menu']: `<div slot="menu">
@@ -48,7 +52,7 @@ export const AllAlignments = (args) => {
   let htmlContent = ``;
   htmlContent += `
   <div style="display: flex; justify-content: space-between; padding: 32px;">
-  <plmg-dropdown align="left" type="nav">
+  <plmg-dropdown align="left" border-radius="var(--plmg-border-radius-pill)">
   <plmg-status slot="trigger" variant="info">Left</plmg-status>
   <div slot="menu">
   <plmg-dropdown-item text="Link" href="https://ducky.eco" target="_blank"></plmg-dropdown-item>
@@ -56,7 +60,7 @@ export const AllAlignments = (args) => {
   <plmg-dropdown-item text="Link" href="https://plumage.ducky.eco/" target="_blank"></plmg-dropdown-item>
   </div>
   </plmg-dropdown>
-    <plmg-dropdown align="right" type="nav">
+    <plmg-dropdown align="right" border-radius="var(--plmg-border-radius-pill)">
     <plmg-status slot="trigger" variant="info">Right</plmg-status>
     <div slot="menu">
     <plmg-dropdown-item text="Link" href="https://ducky.eco" target="_blank"></plmg-dropdown-item>

--- a/packages/component-library/src/components/plmg-dropdown/plmg-dropdown.tsx
+++ b/packages/component-library/src/components/plmg-dropdown/plmg-dropdown.tsx
@@ -74,6 +74,21 @@ export class Dropdown {
   }
 
   /**
+   * Set the border radius of trigger element.
+   *
+   * Allow values:
+   *  - any valid css border radius value
+   *
+   * Default: none
+   */
+  @Prop() borderRadius: string;
+  @Watch('borderRadius')
+  validateBorderRadius(newValue: string) {
+    if (typeof newValue !== 'string')
+      throw new Error('borderRadius: must be a string');
+  }
+
+  /**
    * Invoke this method to manually toggle the dropdown's visibility.
    *
    * Use this method when the document scoped event listeners are disabled.
@@ -160,7 +175,11 @@ export class Dropdown {
     };
 
     return (
-      <nav class={'plmg-dropdown'} tabIndex={0}>
+      <nav
+        class={'plmg-dropdown'}
+        style={this.borderRadius && { borderRadius: this.borderRadius }}
+        tabIndex={0}
+      >
         <slot name={'trigger'} />
         {this.isVisible && (
           <div class={classes}>

--- a/packages/component-library/src/components/plmg-dropdown/readme.md
+++ b/packages/component-library/src/components/plmg-dropdown/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property           | Attribute           | Description                                                                                                                                                               | Type                | Default  |
-| ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | -------- |
-| `align`            | `align`             | Define the alignment of the dropdown menu.  Allowed values:   - left   - right  Default: left                                                                             | `"left" \| "right"` | `'left'` |
-| `disableListeners` | `disable-listeners` | Disable document scoped event listeners.  Does not disable the click event on the trigger element or keyboard events.  Allowed values:   - true   - false  Default: false | `boolean`           | `false`  |
+| Property           | Attribute           | Description                                                                                                                                                               | Type                | Default     |
+| ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------- |
+| `align`            | `align`             | Define the alignment of the dropdown menu.  Allowed values:   - left   - right  Default: left                                                                             | `"left" \| "right"` | `'left'`    |
+| `borderRadius`     | `border-radius`     | Set the border radius of trigger element.  Allow values:  - any valid css border radius value  Default: none                                                              | `string`            | `undefined` |
+| `disableListeners` | `disable-listeners` | Disable document scoped event listeners.  Does not disable the click event on the trigger element or keyboard events.  Allowed values:   - true   - false  Default: false | `boolean`           | `false`     |
 
 
 ## Methods

--- a/packages/component-library/src/components/plmg-dropdown/test/plmg-dropdown.spec.tsx
+++ b/packages/component-library/src/components/plmg-dropdown/test/plmg-dropdown.spec.tsx
@@ -17,4 +17,19 @@ describe('plmg-dropdown', () => {
       </plmg-dropdown>
     `);
   });
+  it('renders with a border radius', async () => {
+    const page = await newSpecPage({
+      components: [Dropdown],
+      html: `<plmg-dropdown border-radius="50%"></plmg-dropdown>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <plmg-dropdown border-radius="50%">
+        <mock:shadow-root>
+        <nav class="plmg-dropdown" tabindex="0" style="border-radius: 50%;">
+        <slot name="trigger"></slot>
+        </nav>
+        </mock:shadow-root>
+      </plmg-dropdown>
+    `);
+  });
 });


### PR DESCRIPTION
Closes [BUG Plmg-Dropdown: Focus is creating blue squares around targets.](https://app.asana.com/0/1200489836971088/1203071646283607/f)

### Summary of changes included in this PR

- Add visible focus ring to nav container element (not fully specced but consistent with every other plumage component implementation)
- Adds a border-radius prop

### Implementation note 
- This is workaround to avoid having to forward focus to the trigger element. Tab focus stay on the nav element. 

### Reviewer checklist:

- Tests for
  - accessibility
  - rendered HTML (spec)
- Storybook stories for all variants
- JSDoc documentation for component
- Update Example app (React, ...)

