### PR TITLE
Fix/button click

### DIFF
--- a/common/changes/@ducky/plumage/fix-buttonClick_2022-10-06-12-09.json
+++ b/common/changes/@ducky/plumage/fix-buttonClick_2022-10-06-12-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage",
+      "comment": "Fixes button click bug",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@ducky/plumage"
+}

--- a/packages/component-library/src/components/plmg-button/plmg-button.tsx
+++ b/packages/component-library/src/components/plmg-button/plmg-button.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, h, Listen, Prop, Watch } from '@stencil/core';
+import { Component, h, Listen, Prop, Watch } from '@stencil/core';
 import {
   isPlmgButtonColor,
   isPlmgButtonSize,
@@ -231,6 +231,7 @@ export class Button {
   @Listen('click')
   handleClick() {
     const clicked = event.target as HTMLElement;
+    console.log('the element clicked is', clicked.tagName);
     if (clicked.tagName === 'PLMG-BUTTON') {
       event.preventDefault();
       event.stopPropagation();

--- a/packages/component-library/src/components/plmg-button/plmg-button.tsx
+++ b/packages/component-library/src/components/plmg-button/plmg-button.tsx
@@ -231,7 +231,6 @@ export class Button {
   @Listen('click')
   handleClick() {
     const clicked = event.target as HTMLElement;
-    console.log('the element clicked is', clicked.tagName);
     if (clicked.tagName === 'PLMG-BUTTON') {
       event.preventDefault();
       event.stopPropagation();

--- a/packages/component-library/src/components/plmg-button/plmg-button.tsx
+++ b/packages/component-library/src/components/plmg-button/plmg-button.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, Watch } from '@stencil/core';
+import { Component, Element, h, Listen, Prop, Watch } from '@stencil/core';
 import {
   isPlmgButtonColor,
   isPlmgButtonSize,
@@ -224,6 +224,17 @@ export class Button {
   validateLabel(newValue: string) {
     if (newValue && typeof newValue !== 'string')
       throw new Error('label must be a string');
+  }
+
+  // get the actual width of the button
+
+  @Listen('click')
+  handleClick() {
+    const clicked = event.target as HTMLElement;
+    if (clicked.tagName === 'PLMG-BUTTON') {
+      event.preventDefault();
+      event.stopPropagation();
+    }
   }
 
   render() {


### PR DESCRIPTION
Closes[BUG PlmgButton - Clicking outside button triggers onClick](https://app.asana.com/0/1200489836971088/1202674646372826/f)

### Summary of changes included in this PR

- Adds a click event listener to the component and suppresses clicks on the plmg-button element. In the click handle function check if PLMG-BUTTON has been clicked and prevent default, prevent propagation. This doesn't prevent the event from the <button> element firing so should be no breaking change.

### Reviewer checklist:

- Tests for
  - accessibility
  - rendered HTML (spec)
- Storybook stories for all variants
- JSDoc documentation for component
- Update Example app (React, ...)

