### PR TITLE
Fix/side bar parent active

### DIFF
--- a/common/changes/@ducky/plumage/fix-sideBarParentActive_2022-11-08-13-22.json
+++ b/common/changes/@ducky/plumage/fix-sideBarParentActive_2022-11-08-13-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage",
+      "comment": "Fixes sidebar item bug (setting active child to false triggers parent style)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@ducky/plumage"
+}

--- a/packages/component-library/src/components/plmg-sidebar-item/plmg-sidebar-item.tsx
+++ b/packages/component-library/src/components/plmg-sidebar-item/plmg-sidebar-item.tsx
@@ -182,7 +182,8 @@ export class SidebarItem {
   private hasActiveChild(): boolean {
     return Array.from(this.el.children).some(
       (child: HTMLElement) =>
-        child.tagName === 'PLMG-SIDEBAR-ITEM' && child.getAttribute('active')
+        child.tagName === 'PLMG-SIDEBAR-ITEM' &&
+        child.getAttribute('active') === 'true'
     );
   }
 


### PR DESCRIPTION
<!-- List all User Stories / Bug / Task addressed in this PR. Add one line per Asana link. -->

Closes[BUG] Plmg-SideBar: Parent component should be styled when child is active] (https://app.asana.com/0/1200489836971088/1203268487303999/f)

### Summary of changes included in this PR

- Checks that when parent has a child with the active attribute, that the attribute is true. (Previously it just checked that the attribute exists, so if active=false this would still trigger that active parent class)

### Reviewer checklist:

- Tests for
  - accessibility
  - rendered HTML (spec)
- Storybook stories for all variants
- JSDoc documentation for component
- Update Example app (React, ...)

