### PR TITLE
Use random IDs for text input, fix label styling

### DIFF
--- a/common/changes/@ducky/plumage/fix-plmgtextinput-label_2023-05-22-11-26.json
+++ b/common/changes/@ducky/plumage/fix-plmgtextinput-label_2023-05-22-11-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage",
+      "comment": "plmg-text-input elements use randommized id values, and fixes styling",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@ducky/plumage"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -17341,6 +17341,11 @@ packages:
     hasBin: true
     dev: false
 
+  /uuid/9.0.0:
+    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+    hasBin: true
+    dev: false
+
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
     dev: false
@@ -18113,7 +18118,7 @@ packages:
     dev: false
 
   file:projects/example-react-app.tgz:
-    resolution: {integrity: sha512-LQeeJ000bsM9mWX9mH04AgSzrFpcYUUDH+6hyk7P2inFvbILfgeQNkfi+w0bdvreEwVwmsUGMAMWBg39I8U1+g==, tarball: file:projects/example-react-app.tgz}
+    resolution: {integrity: sha512-WH2u9sb+rIlLmsNV9CB/nq4vyTkuPgZuWG9jwwm/jBpNduH9rLuAUZgo3vRZ/zqYZZK2ThImekBDEtUWQVAgkg==, tarball: file:projects/example-react-app.tgz}
     name: '@rush-temp/example-react-app'
     version: 0.0.0
     dependencies:
@@ -18151,7 +18156,7 @@ packages:
     dev: false
 
   file:projects/plumage-react.tgz:
-    resolution: {integrity: sha512-FfcKCJC/3ko0WAYgz9mrLuZSwgeWnDn8vehaNqC2Vl+J4v7BoyjIyhCk3+rUMCaMMzK+cU0q3mi+7lN6eBcAbw==, tarball: file:projects/plumage-react.tgz}
+    resolution: {integrity: sha512-MIJXp5RkaL671jQcdRSf6hJGgES2onasSFnvRdKRcwc9MaeOX/OD/Lc0VRuC7TXeWb6zKKlpVR/bsEWQbuFs/A==, tarball: file:projects/plumage-react.tgz}
     name: '@rush-temp/plumage-react'
     version: 0.0.0
     dependencies:
@@ -18175,7 +18180,7 @@ packages:
     dev: false
 
   file:projects/plumage.tgz_2743be61cb4a6f37f54c738ff73146e0:
-    resolution: {integrity: sha512-7AP14zjvKnJdrdgpEBrySnFGDTxMz+8nSnYokRHioIyJPOLKo8bB+jGuPtJfr1YGKNMy5ZKGQsJH0cQ9w2FmLQ==, tarball: file:projects/plumage.tgz}
+    resolution: {integrity: sha512-zdIYuOXopyz4D5N7F5uGWPgjJTPniK+t5vyRfePOBpFzSfE8Uv7v1q2PeWfBN/OitgrIq0SO9uVvHfXlph96rg==, tarball: file:projects/plumage.tgz}
     id: file:projects/plumage.tgz
     name: '@rush-temp/plumage'
     version: 0.0.0
@@ -18219,6 +18224,7 @@ packages:
       storybook-addon-designs: 6.3.1
       svgo: 2.8.0
       typescript: 4.7.4
+      uuid: 9.0.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@storybook/angular'
@@ -18260,7 +18266,7 @@ packages:
     dev: false
 
   file:projects/vite-react-app.tgz_sass@1.54.4:
-    resolution: {integrity: sha512-v2FWVJGVSrrHg0eKIsDIxhdW4xAgc1sivjud5ZXaleIGPrXQwPpkLy55bZnBifLXvyUOoTjWUVY6GLxEOWCdAg==, tarball: file:projects/vite-react-app.tgz}
+    resolution: {integrity: sha512-X3YS0iRSQlDudjaNihTVn6MJ4Vm63JqzM/sQZdt/P0V1GDUngpFpPOpPN1/c+EI9kt2+i6n3fcHkY4DY3Y48hQ==, tarball: file:projects/vite-react-app.tgz}
     id: file:projects/vite-react-app.tgz
     name: '@rush-temp/vite-react-app'
     version: 0.0.0

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -17341,11 +17341,6 @@ packages:
     hasBin: true
     dev: false
 
-  /uuid/9.0.0:
-    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
-    hasBin: true
-    dev: false
-
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
     dev: false
@@ -18118,7 +18113,7 @@ packages:
     dev: false
 
   file:projects/example-react-app.tgz:
-    resolution: {integrity: sha512-WH2u9sb+rIlLmsNV9CB/nq4vyTkuPgZuWG9jwwm/jBpNduH9rLuAUZgo3vRZ/zqYZZK2ThImekBDEtUWQVAgkg==, tarball: file:projects/example-react-app.tgz}
+    resolution: {integrity: sha512-LQeeJ000bsM9mWX9mH04AgSzrFpcYUUDH+6hyk7P2inFvbILfgeQNkfi+w0bdvreEwVwmsUGMAMWBg39I8U1+g==, tarball: file:projects/example-react-app.tgz}
     name: '@rush-temp/example-react-app'
     version: 0.0.0
     dependencies:
@@ -18156,7 +18151,7 @@ packages:
     dev: false
 
   file:projects/plumage-react.tgz:
-    resolution: {integrity: sha512-MIJXp5RkaL671jQcdRSf6hJGgES2onasSFnvRdKRcwc9MaeOX/OD/Lc0VRuC7TXeWb6zKKlpVR/bsEWQbuFs/A==, tarball: file:projects/plumage-react.tgz}
+    resolution: {integrity: sha512-FfcKCJC/3ko0WAYgz9mrLuZSwgeWnDn8vehaNqC2Vl+J4v7BoyjIyhCk3+rUMCaMMzK+cU0q3mi+7lN6eBcAbw==, tarball: file:projects/plumage-react.tgz}
     name: '@rush-temp/plumage-react'
     version: 0.0.0
     dependencies:
@@ -18180,7 +18175,7 @@ packages:
     dev: false
 
   file:projects/plumage.tgz_2743be61cb4a6f37f54c738ff73146e0:
-    resolution: {integrity: sha512-zdIYuOXopyz4D5N7F5uGWPgjJTPniK+t5vyRfePOBpFzSfE8Uv7v1q2PeWfBN/OitgrIq0SO9uVvHfXlph96rg==, tarball: file:projects/plumage.tgz}
+    resolution: {integrity: sha512-7AP14zjvKnJdrdgpEBrySnFGDTxMz+8nSnYokRHioIyJPOLKo8bB+jGuPtJfr1YGKNMy5ZKGQsJH0cQ9w2FmLQ==, tarball: file:projects/plumage.tgz}
     id: file:projects/plumage.tgz
     name: '@rush-temp/plumage'
     version: 0.0.0
@@ -18224,7 +18219,6 @@ packages:
       storybook-addon-designs: 6.3.1
       svgo: 2.8.0
       typescript: 4.7.4
-      uuid: 9.0.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@storybook/angular'
@@ -18266,7 +18260,7 @@ packages:
     dev: false
 
   file:projects/vite-react-app.tgz_sass@1.54.4:
-    resolution: {integrity: sha512-X3YS0iRSQlDudjaNihTVn6MJ4Vm63JqzM/sQZdt/P0V1GDUngpFpPOpPN1/c+EI9kt2+i6n3fcHkY4DY3Y48hQ==, tarball: file:projects/vite-react-app.tgz}
+    resolution: {integrity: sha512-v2FWVJGVSrrHg0eKIsDIxhdW4xAgc1sivjud5ZXaleIGPrXQwPpkLy55bZnBifLXvyUOoTjWUVY6GLxEOWCdAg==, tarball: file:projects/vite-react-app.tgz}
     id: file:projects/vite-react-app.tgz
     name: '@rush-temp/vite-react-app'
     version: 0.0.0

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -35,7 +35,8 @@
     "postgenerate-icons": "npm run generate-icon-enum"
   },
   "dependencies": {
-    "@ducky/plumage-tokens": "^5.0.0"
+    "@ducky/plumage-tokens": "^5.0.0",
+    "uuid": "~9.0.0"
   },
   "devDependencies": {
     "@axe-core/puppeteer": "~4.4.0",

--- a/packages/component-library/src/components/plmg-text-input/plmg-text-input.tsx
+++ b/packages/component-library/src/components/plmg-text-input/plmg-text-input.tsx
@@ -8,6 +8,7 @@ import {
   Event,
   EventEmitter,
 } from '@stencil/core';
+import { v4 as uuidv4 } from 'uuid';
 import {
   isPlmgTextInputSize,
   PlmgTextInputType,
@@ -21,6 +22,7 @@ import {
   shadow: false,
 })
 export class TextInput {
+  private inputId: string;
   /**
    * Reference to host HTML element.
    */
@@ -377,6 +379,7 @@ export class TextInput {
 
   componentWillLoad() {
     this.validateSize(this.size);
+    this.inputId = this.generateId();
   }
 
   render() {
@@ -399,39 +402,39 @@ export class TextInput {
 
     return (
       <div class={'plmg-text-input-wrapper'}>
-        <label class={labelClasses}>
+        <label class={labelClasses} htmlFor={this.inputId}>
           {this.label}
           {this.showLabel && this.required && <span class={'required'}>*</span>}
-          <input
-            autoComplete={this.autoComplete}
-            class={inputClasses}
-            disabled={this.disabled}
-            max={this.max}
-            maxlength={this.maxLength}
-            min={this.min}
-            minlength={this.minLength}
-            name={this.name}
-            onInput={(event) => this.handleInputChange(event.target)}
-            pattern={this.pattern}
-            placeholder={this.placeholder}
-            readonly={this.readOnly}
-            required={this.required}
-            step={this.step}
-            style={{
-              width: this.width && this.width + 'px',
-            }}
-            // supresss the default browser validation popup
-            title={''}
-            type={this.type}
-            value={this.internalValue}
-            onWheel={(e) => {
-              if (e.target instanceof HTMLElement) {
-                e.target.blur();
-              }
-            }}
-          />
         </label>
-
+        <input
+          id={this.inputId}
+          autoComplete={this.autoComplete}
+          class={inputClasses}
+          disabled={this.disabled}
+          max={this.max}
+          maxlength={this.maxLength}
+          min={this.min}
+          minlength={this.minLength}
+          name={this.name}
+          onInput={(event) => this.handleInputChange(event.target)}
+          pattern={this.pattern}
+          placeholder={this.placeholder}
+          readonly={this.readOnly}
+          required={this.required}
+          step={this.step}
+          style={{
+            width: this.width && this.width + 'px',
+          }}
+          // supress the default browser validation popup
+          title={''}
+          type={this.type}
+          value={this.internalValue}
+          onWheel={(e) => {
+            if (e.target instanceof HTMLElement) {
+              e.target.blur();
+            }
+          }}
+        />
         {this.tip && <span class={tipClasses}>{this.tip}</span>}
         {this.errorMessage && (
           <plmg-error-message
@@ -442,5 +445,9 @@ export class TextInput {
         )}
       </div>
     );
+  }
+
+  private generateId() {
+    return `plmg-${uuidv4()}`;
   }
 }

--- a/packages/component-library/src/components/plmg-text-input/test/plmg-text-input.spec.tsx
+++ b/packages/component-library/src/components/plmg-text-input/test/plmg-text-input.spec.tsx
@@ -1,5 +1,18 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { TextInput } from '../plmg-text-input';
+import type { AnyHTMLElement } from '@stencil/core/internal';
+
+//The values for the input id are randomly generated, so we
+//can't expect a certain value for them in our test strings.
+//I don't think toEqualHtml() allows regex. I'm removing the
+//randomized attributes instead before checking the html equals
+//the string
+const removeUUIDAttributes = (pageRoot: AnyHTMLElement) => {
+  const label = pageRoot.getElementsByTagName('label');
+  label[0].removeAttribute('htmlFor');
+  const input = pageRoot.getElementsByTagName('input');
+  input[0].removeAttribute('id');
+};
 
 describe('plmg-text-input', () => {
   it('renders default', async () => {
@@ -7,13 +20,15 @@ describe('plmg-text-input', () => {
       components: [TextInput],
       html: `<plmg-text-input label="Default"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input label="Default">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           Default
-          <input autocomplete="off" class="medium full-width" type="text"/>
         </label>
+        <input autocomplete="off" class="medium full-width" type="text"/>
       </div>
     </plmg-text-input>
     `);
@@ -24,13 +39,16 @@ describe('plmg-text-input', () => {
       components: [TextInput],
       html: `<plmg-text-input label="Default" name="my-name"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input label="Default" name="my-name">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           Default
-          <input autocomplete="off" class="medium full-width" name="my-name" type="text"/>
         </label>
+
+        <input autocomplete="off" class="medium full-width" name="my-name" type="text"/>
       </div>
     </plmg-text-input>
     `);
@@ -41,13 +59,15 @@ describe('plmg-text-input', () => {
       components: [TextInput],
       html: `<plmg-text-input size="large" width="20" label="Large"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input label="Large" size="large" width="20">
       <div class="plmg-text-input-wrapper">
         <label class="large plmg-text-input-label">
           Large
-          <input autocomplete="off" class="large" style="width: 20px;" type="text" />
         </label>
+        <input autocomplete="off" class="large" style="width: 20px;" type="text" />
       </div>
     </plmg-text-input>
     `);
@@ -58,13 +78,15 @@ describe('plmg-text-input', () => {
       components: [TextInput],
       html: `<plmg-text-input min-length="5" label="Min Length"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input min-length="5" label="Min Length">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           Min Length
-          <input autocomplete="off" class="medium full-width" type="text" minlength="5"/>
         </label>
+        <input autocomplete="off" class="medium full-width" type="text" minlength="5"/>
       </div>
     </plmg-text-input>
     `);
@@ -75,13 +97,15 @@ describe('plmg-text-input', () => {
       components: [TextInput],
       html: `<plmg-text-input max-length="10" label="Max Length"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input max-length="10" label="Max Length">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           Max Length
-          <input autocomplete="off" class="medium full-width" type="text" maxlength="10"/>
         </label>
+        <input autocomplete="off" class="medium full-width" type="text" maxlength="10"/>
       </div>
     </plmg-text-input>
     `);
@@ -92,13 +116,15 @@ describe('plmg-text-input', () => {
       components: [TextInput],
       html: `<plmg-text-input size="large" label="Large"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input label="Large" size="large">
       <div class="plmg-text-input-wrapper">
         <label class="large plmg-text-input-label">
           Large
-          <input autocomplete="off" class="full-width large" type="text"/>
         </label>
+        <input autocomplete="off" class="full-width large" type="text"/>
       </div>
     </plmg-text-input>
     `);
@@ -109,6 +135,8 @@ describe('plmg-text-input', () => {
       components: [TextInput],
       html: `<plmg-text-input show-label="false" label="Hidden"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input label="Hidden" show-label="false">
       <div class="plmg-text-input-wrapper">
@@ -117,8 +145,8 @@ describe('plmg-text-input', () => {
          
         >
           Hidden
-          <input autocomplete="off" class="medium full-width" type="text"/>
         </label>
+        <input autocomplete="off" class="medium full-width" type="text"/>
       </div>
     </plmg-text-input>
     `);
@@ -129,13 +157,15 @@ describe('plmg-text-input', () => {
       components: [TextInput],
       html: `<plmg-text-input tip="Tip Text" label="Tip"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input label="Tip" tip="Tip Text">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           Tip
-          <input autocomplete="off" class="medium full-width" type="text"/>
         </label>
+        <input autocomplete="off" class="medium full-width" type="text"/>
         <span class="medium plmg-text-input-tip">Tip Text</span>
       </div>
     </plmg-text-input>
@@ -147,13 +177,15 @@ describe('plmg-text-input', () => {
       components: [TextInput],
       html: `<plmg-text-input error-message="error" label="Error"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input label="Error" error-message="error">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           Error
-        <input autocomplete="off" class="error medium full-width" type="text"/>
         </label>
+        <input autocomplete="off" class="error medium full-width" type="text"/>
         <plmg-error-message
           message="error"
           size="medium"
@@ -169,13 +201,15 @@ describe('plmg-text-input', () => {
       components: [TextInput],
       html: `<plmg-text-input disabled="true" label="disabled"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input disabled="true" label="disabled">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           disabled
-          <input autocomplete="off" class="medium full-width" disabled type="text">
         </label>
+        <input autocomplete="off" class="medium full-width" disabled type="text">
       </div>
     </plmg-text-input>
     `);
@@ -186,13 +220,15 @@ describe('plmg-text-input', () => {
       components: [TextInput],
       html: `<plmg-text-input read-only="true" label="read-only"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input read-only="true" label="read-only">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           read-only
-        <input autocomplete="off" class="medium full-width" readonly type="text"/>
         </label>
+        <input autocomplete="off" class="medium full-width" readonly type="text"/>
       </div>
     </plmg-text-input>
     `);
@@ -203,13 +239,15 @@ describe('plmg-text-input', () => {
       components: [TextInput],
       html: `<plmg-text-input auto-complete="on" label="autocomplete"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input auto-complete="on" label="autocomplete">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           autocomplete
-          <input autocomplete="on" class="medium full-width" type="text"/>
         </label>
+        <input autocomplete="on" class="medium full-width" type="text"/>
       </div>
     </plmg-text-input>
     `);
@@ -220,13 +258,15 @@ describe('plmg-text-input', () => {
       components: [TextInput],
       html: `<plmg-text-input placeholder="placeholder" label="placeholder"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input placeholder="placeholder" label="placeholder">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           placeholder
-          <input autocomplete="off" placeholder="placeholder" class="medium full-width" type="text"/>
         </label>
+        <input autocomplete="off" placeholder="placeholder" class="medium full-width" type="text"/>
       </div>
     </plmg-text-input>
     `);
@@ -250,13 +290,15 @@ describe('plmg-text-input types', () => {
       components: [TextInput],
       html: `<plmg-text-input label="Default"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input label="Default">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           Default
-        <input autocomplete="off" class="medium full-width" type="text"/>
         </label>
+        <input autocomplete="off" class="medium full-width" type="text"/>
       </div>
     </plmg-text-input>
     `);
@@ -267,13 +309,15 @@ describe('plmg-text-input types', () => {
       components: [TextInput],
       html: `<plmg-text-input type="password" label="password"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input label="password" type="password">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           password
-          <input autocomplete="off" type="password" class="medium full-width"/>
         </label>
+        <input autocomplete="off" type="password" class="medium full-width"/>
       </div>
     </plmg-text-input>
     `);
@@ -284,13 +328,15 @@ describe('plmg-text-input types', () => {
       components: [TextInput],
       html: `<plmg-text-input type="email" label="email"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
       <plmg-text-input label="email" type="email">
         <div class="plmg-text-input-wrapper">
           <label class="medium plmg-text-input-label">
             email
-            <input autocomplete="off" type="email" class="medium full-width"/>
           </label>
+          <input autocomplete="off" type="email" class="medium full-width"/>
         </div>
       </plmg-text-input>
     `);
@@ -301,13 +347,15 @@ describe('plmg-text-input types', () => {
       components: [TextInput],
       html: `<plmg-text-input type="email" label="email"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
       <plmg-text-input label="email" type="email">
         <div class="plmg-text-input-wrapper">
           <label class="medium plmg-text-input-label">
             email
+          </label>
           <input autocomplete="off" type="email" class="medium full-width" type="text"/>
-          </label>
         </div>
       </plmg-text-input>
     `);
@@ -318,13 +366,15 @@ describe('plmg-text-input types', () => {
       components: [TextInput],
       html: `<plmg-text-input type="email" label="email"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
       <plmg-text-input label="email" type="email">
         <div class="plmg-text-input-wrapper">
           <label class="medium plmg-text-input-label">
             email
-            <input autocomplete="off" type="email" class="medium full-width" type="text"/>
           </label>
+          <input autocomplete="off" type="email" class="medium full-width" type="text"/>
         </div>
       </plmg-text-input>
     `);
@@ -335,13 +385,15 @@ describe('plmg-text-input types', () => {
       components: [TextInput],
       html: `<plmg-text-input type="tel" label="tel"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
       <plmg-text-input label="tel" type="tel">
         <div class="plmg-text-input-wrapper">
           <label class="medium plmg-text-input-label">
             tel
-            <input autocomplete="off" type="tel" class="medium full-width"/>
           </label>
+          <input autocomplete="off" type="tel" class="medium full-width"/>
         </div>
       </plmg-text-input>
     `);
@@ -352,13 +404,15 @@ describe('plmg-text-input types', () => {
       components: [TextInput],
       html: `<plmg-text-input type="url" label="url"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
       <plmg-text-input label="url" type="url">
         <div class="plmg-text-input-wrapper">
           <label class="medium plmg-text-input-label">
             url
-            <input autocomplete="off" type="url" class="medium full-width">
           </label>
+          <input autocomplete="off" type="url" class="medium full-width">
         </div>
       </plmg-text-input>
     `);
@@ -369,13 +423,15 @@ describe('plmg-text-input types', () => {
       components: [TextInput],
       html: `<plmg-text-input type="search" label="search"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
       <plmg-text-input label="search" type="search">
         <div class="plmg-text-input-wrapper">
           <label class="medium plmg-text-input-label">
             search
-            <input autocomplete="off" type="search" class="medium full-width"/>
           </label>
+          <input autocomplete="off" type="search" class="medium full-width"/>
         </div>
       </plmg-text-input>
     `);
@@ -388,13 +444,15 @@ describe('plmg-text-input type: number', () => {
       components: [TextInput],
       html: `<plmg-text-input type="number" label="number"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input type="number" label="number">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           number
-          <input autocomplete="off" class="medium full-width" type="number"/>
         </label>
+        <input autocomplete="off" class="medium full-width" type="number"/>
       </div>
     </plmg-text-input>
     `);
@@ -405,13 +463,15 @@ describe('plmg-text-input type: number', () => {
       components: [TextInput],
       html: `<plmg-text-input type="number" min="0" label="number"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input type="number" min="0" label="number">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           number
-          <input autocomplete="off" class="medium full-width" type="number" min="0"/>
         </label>
+        <input autocomplete="off" class="medium full-width" type="number" min="0"/>
       </div>
     </plmg-text-input>
     `);
@@ -421,13 +481,15 @@ describe('plmg-text-input type: number', () => {
       components: [TextInput],
       html: `<plmg-text-input type="number" max="10" label="number"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input type="number" max="10"label="number">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           number
-          <input autocomplete="off" class="medium full-width" type="number" max="10"/>
         </label>
+        <input autocomplete="off" class="medium full-width" type="number" max="10"/>
       </div>
     </plmg-text-input>
     `);
@@ -437,13 +499,15 @@ describe('plmg-text-input type: number', () => {
       components: [TextInput],
       html: `<plmg-text-input type="number" step="10" label="number"></plmg-text-input>`,
     });
+    removeUUIDAttributes(page.root);
+
     expect(page.root).toEqualHtml(`
     <plmg-text-input type="number" step="10" label="number">
       <div class="plmg-text-input-wrapper">
         <label class="medium plmg-text-input-label">
           number
-          <input autocomplete="off" class="medium full-width" type="number" step="10"/>
         </label>
+        <input autocomplete="off" class="medium full-width" type="number" step="10"/>
       </div>
     </plmg-text-input>
     `);


### PR DESCRIPTION
<!-- List all User Stories / Bug / Task addressed in this PR. Add one line per Asana link. -->

Closes none

### Summary of changes included in this PR

- Noticed that we had a bit of a styling issue after the last release, because the label was wrapping the input tag. This was causing some margins to be misplaced, so now we're back to a sibling label and input, but with randomized IDs for the input

### Reviewer checklist:

- Tests for
  - accessibility
  - rendered HTML (spec)
- Storybook stories for all variants
- JSDoc documentation for component
- Update Example app (React, ...)

