### PR TITLE
fix(svg/button):trigger parent button

### DIFF
--- a/common/changes/@ducky/plumage/fix-plmg-svg-icon_2023-08-08-14-24.json
+++ b/common/changes/@ducky/plumage/fix-plmg-svg-icon_2023-08-08-14-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@ducky/plumage",
+      "comment": "Fixes `plmg-button` icon click behavior with new `triggerButtonOnClick` prop, allowing icon clicks to trigger parent button actions.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@ducky/plumage"
+}

--- a/examples/react-app/src/index.tsx
+++ b/examples/react-app/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useState, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import {
   PlmgButton,
@@ -77,6 +77,49 @@ const ButtonDisabledExample = () => {
       disabled={buttonDisabled}
       text={buttonDisabled ? 'I am disabled...' : 'I am enabled!'}
     />
+  );
+};
+
+const Modal = ({ isOpen, onClose }) => {
+  const dialogRef = useRef(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      dialogRef.current.showModal();
+    } else {
+      dialogRef.current.close();
+    }
+  }, [isOpen]);
+
+  return (
+    <dialog ref={dialogRef}>
+      <PlmgButton
+        iconCenter="close"
+        label="close"
+        design="borderless"
+        onClick={onClose}
+      />
+      I am modal
+    </dialog>
+  );
+};
+
+const ModalWrapper = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+
+  return (
+    <div>
+      <PlmgButton onClick={openModal} text="Open Modal" />
+      <Modal isOpen={isModalOpen} onClose={closeModal} />
+    </div>
   );
 };
 
@@ -176,6 +219,7 @@ ReactDOM.render(
       <PlmgRadioButton name="dairy" value={'cheese'} checked={true} />
       Single Radio Button without checked set
       <PlmgRadioButton name="dairy" value={'cheese'} />
+      <ModalWrapper />
       <PlmgSeparator />
       <br />
       <PlmgCard

--- a/packages/component-library/src/components.d.ts
+++ b/packages/component-library/src/components.d.ts
@@ -381,6 +381,10 @@ export namespace Components {
           * Define the icon's size.  Allowed values: <value><unit>  Examples: - 1em - 42px  Default: 1em
          */
         "size": string;
+        /**
+          * Allow the icon to trigger click on the closest parent button. Default: false
+         */
+        "triggerButtonOnClick": boolean;
     }
     interface PlmgTab {
         /**
@@ -1071,6 +1075,10 @@ declare namespace LocalJSX {
           * Define the icon's size.  Allowed values: <value><unit>  Examples: - 1em - 42px  Default: 1em
          */
         "size"?: string;
+        /**
+          * Allow the icon to trigger click on the closest parent button. Default: false
+         */
+        "triggerButtonOnClick"?: boolean;
     }
     interface PlmgTab {
         /**

--- a/packages/component-library/src/components/plmg-button/plmg-button.tsx
+++ b/packages/component-library/src/components/plmg-button/plmg-button.tsx
@@ -301,14 +301,14 @@ export class Button {
               <plmg-svg-icon
                 class={'icon-left'}
                 icon={this.iconLeft}
-                triggerButtonOnClick
+                trigger-button-on-click
               />
             )}
             {this.hasIconCenter() && (
               <plmg-svg-icon
                 class={'icon-center'}
                 icon={this.iconCenter}
-                triggerButtonOnClick
+                trigger-button-on-click
               />
             )}
             {this.text}
@@ -316,7 +316,7 @@ export class Button {
               <plmg-svg-icon
                 class={'icon-right'}
                 icon={this.iconRight}
-                triggerButtonOnClick
+                trigger-button-on-click
               />
             )}
           </a>
@@ -337,14 +337,14 @@ export class Button {
             <plmg-svg-icon
               class={'icon-left'}
               icon={this.iconLeft}
-              triggerButtonOnClick
+              trigger-button-on-click
             />
           )}
           {this.hasIconCenter() && (
             <plmg-svg-icon
               class={'icon-center'}
               icon={this.iconCenter}
-              triggerButtonOnClick
+              trigger-button-on-click
             />
           )}
           {this.text}
@@ -352,7 +352,7 @@ export class Button {
             <plmg-svg-icon
               class={'icon-right'}
               icon={this.iconRight}
-              triggerButtonOnClick
+              trigger-button-on-click
             />
           )}
         </button>

--- a/packages/component-library/src/components/plmg-button/plmg-button.tsx
+++ b/packages/component-library/src/components/plmg-button/plmg-button.tsx
@@ -298,14 +298,26 @@ export class Button {
             aria-disabled={this.disabled}
           >
             {this.hasIconLeft() && (
-              <plmg-svg-icon class={'icon-left'} icon={this.iconLeft} />
+              <plmg-svg-icon
+                class={'icon-left'}
+                icon={this.iconLeft}
+                triggerButtonOnClick
+              />
             )}
             {this.hasIconCenter() && (
-              <plmg-svg-icon class={'icon-center'} icon={this.iconCenter} />
+              <plmg-svg-icon
+                class={'icon-center'}
+                icon={this.iconCenter}
+                triggerButtonOnClick
+              />
             )}
             {this.text}
             {this.hasIconRight() && (
-              <plmg-svg-icon class={'icon-right'} icon={this.iconRight} />
+              <plmg-svg-icon
+                class={'icon-right'}
+                icon={this.iconRight}
+                triggerButtonOnClick
+              />
             )}
           </a>
         </Host>
@@ -322,14 +334,26 @@ export class Button {
           style={{ pointerEvents: this.disabled ? 'none' : 'auto' }}
         >
           {this.hasIconLeft() && (
-            <plmg-svg-icon class={'icon-left'} icon={this.iconLeft} />
+            <plmg-svg-icon
+              class={'icon-left'}
+              icon={this.iconLeft}
+              triggerButtonOnClick
+            />
           )}
           {this.hasIconCenter() && (
-            <plmg-svg-icon class={'icon-center'} icon={this.iconCenter} />
+            <plmg-svg-icon
+              class={'icon-center'}
+              icon={this.iconCenter}
+              triggerButtonOnClick
+            />
           )}
           {this.text}
           {this.hasIconRight() && (
-            <plmg-svg-icon class={'icon-right'} icon={this.iconRight} />
+            <plmg-svg-icon
+              class={'icon-right'}
+              icon={this.iconRight}
+              triggerButtonOnClick
+            />
           )}
         </button>
       </Host>

--- a/packages/component-library/src/components/plmg-button/test/plmg-button.e2e.ts
+++ b/packages/component-library/src/components/plmg-button/test/plmg-button.e2e.ts
@@ -167,7 +167,7 @@ describe('plmg-button', () => {
       it('should trigger button click when SVG is clicked', async () => {
         const page = await newE2EPage();
         const htmlContent = `
-          <plmg-button triggerButtonOnClick="true" icon-left="home"></plmg-button>
+          <plmg-button icon-left="home"></plmg-button>
         `;
 
         await page.setContent(htmlContent);

--- a/packages/component-library/src/components/plmg-button/test/plmg-button.e2e.ts
+++ b/packages/component-library/src/components/plmg-button/test/plmg-button.e2e.ts
@@ -162,4 +162,28 @@ describe('plmg-button', () => {
       expect(buttonClickedSpy).toHaveReceivedEventTimes(0);
     });
   });
+  describe('plmg-button SVG click delegation', () => {
+    describe('with triggerButtonOnClick set to true', () => {
+      it('should trigger button click when SVG is clicked', async () => {
+        const page = await newE2EPage();
+        const htmlContent = `
+          <plmg-button triggerButtonOnClick="true" icon-left="home"></plmg-button>
+        `;
+
+        await page.setContent(htmlContent);
+
+        const svgElement = await page.find('plmg-button plmg-svg-icon');
+        const button = await page.find('plmg-button button');
+
+        console.log(svgElement);
+
+        // Spies for both button and SVG element.
+        const buttonClickedSpy = await button.spyOnEvent('click');
+
+        await svgElement.click();
+
+        expect(buttonClickedSpy).toHaveReceivedEvent();
+      });
+    });
+  });
 });

--- a/packages/component-library/src/components/plmg-button/test/plmg-button.e2e.ts
+++ b/packages/component-library/src/components/plmg-button/test/plmg-button.e2e.ts
@@ -175,9 +175,6 @@ describe('plmg-button', () => {
         const svgElement = await page.find('plmg-button plmg-svg-icon');
         const button = await page.find('plmg-button button');
 
-        console.log(svgElement);
-
-        // Spies for both button and SVG element.
         const buttonClickedSpy = await button.spyOnEvent('click');
 
         await svgElement.click();

--- a/packages/component-library/src/components/plmg-button/test/plmg-button.spec.tsx
+++ b/packages/component-library/src/components/plmg-button/test/plmg-button.spec.tsx
@@ -66,10 +66,10 @@ describe('plmg-button', () => {
     expect(page.root).toEqualHtml(`
     <plmg-button icon-center="home" icon-left="home" icon-right="home" text="Content" style="width: fit-content;">
          <button class="filled icon-button medium plmg-button primary" type="button" style="pointer-events: auto;">
-           <plmg-svg-icon class="icon-left" icon="home"></plmg-svg-icon>
-           <plmg-svg-icon class="icon-center" icon="home"></plmg-svg-icon>
+           <plmg-svg-icon class="icon-left" icon="home" trigger-button-on-click></plmg-svg-icon>
+           <plmg-svg-icon class="icon-center" icon="home" trigger-button-on-click></plmg-svg-icon>
            Content
-           <plmg-svg-icon class="icon-right" icon="home"></plmg-svg-icon>
+           <plmg-svg-icon class="icon-right" icon="home" trigger-button-on-click></plmg-svg-icon>
          </button>
 
     `);
@@ -83,7 +83,7 @@ describe('plmg-button', () => {
     expect(page.root).toEqualHtml(`
     <plmg-button icon-center="home" label="test" style="width: fit-content;">
          <button aria-label="test" class="filled icon-button medium plmg-button primary" type="button" style="pointer-events: auto;">
-           <plmg-svg-icon class="icon-center" icon="home"></plmg-svg-icon>
+           <plmg-svg-icon class="icon-center" icon="home" trigger-button-on-click></plmg-svg-icon>
          </button>
       </plmg-button>
     `);
@@ -97,7 +97,7 @@ describe('plmg-button', () => {
     expect(page.root).toEqualHtml(`
       <plmg-button full-width="true" icon-center="home" label="test" style="width: full-width;">
            <button aria-label="test" class="filled full-width icon-button medium plmg-button primary" type="button" style="pointer-events: auto;">
-             <plmg-svg-icon class="icon-center" icon="home"></plmg-svg-icon>
+             <plmg-svg-icon class="icon-center" icon="home" trigger-button-on-click></plmg-svg-icon>
            </button>
         </plmg-button>
       `);

--- a/packages/component-library/src/components/plmg-svg-icon/plmg-svg-icon.tsx
+++ b/packages/component-library/src/components/plmg-svg-icon/plmg-svg-icon.tsx
@@ -5,6 +5,7 @@ import {
   Prop,
   h,
   Watch,
+  Listen,
   Build,
 } from '@stencil/core';
 import { fetchIcon, supportsIntersectionObserver } from './utils';
@@ -59,6 +60,29 @@ export class SvgIcon {
   @State() private pathData: string;
   @State() private visible = false;
   private intersectionObserver: IntersectionObserver;
+
+  /**
+   * Allow the icon to trigger click on the closest parent button.
+   * Default: false
+   */
+  @Prop() triggerButtonOnClick: boolean = false;
+  @Watch('triggerButtonOnClick')
+  validateDisabled(newValue: boolean) {
+    if (typeof newValue !== 'boolean')
+      throw new Error('disabled: must be boolean');
+  }
+  @Listen('click')
+  handleClick(event: Event) {
+    if (!this.triggerButtonOnClick) return;
+
+    event.stopPropagation();
+    const targetElem = event.target as HTMLElement;
+    const button = targetElem.closest('button');
+
+    if (button) {
+      button.click();
+    }
+  }
 
   // When connected to the DOM
   connectedCallback(): void {

--- a/packages/component-library/src/components/plmg-svg-icon/readme.md
+++ b/packages/component-library/src/components/plmg-svg-icon/readme.md
@@ -7,11 +7,12 @@
 
 ## Properties
 
-| Property | Attribute | Description                                                                                                                                           | Type     | Default     |
-| -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| `color`  | `color`   | Define icon's color.  Can be any valid CSS color value.  By default, the icon will have the same color as the parent's element.                       | `string` | `undefined` |
-| `icon`   | `icon`    | Define icon by its name. Name must be one of the existing icon: https://components.ducky.eco/?path=/story/component-svgicon--all-icons  Default: NULL | `string` | `null`      |
-| `size`   | `size`    | Define the icon's size.  Allowed values: <value><unit>  Examples: - 1em - 42px  Default: 1em                                                          | `string` | `'1em'`     |
+| Property               | Attribute                 | Description                                                                                                                                           | Type      | Default     |
+| ---------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `color`                | `color`                   | Define icon's color.  Can be any valid CSS color value.  By default, the icon will have the same color as the parent's element.                       | `string`  | `undefined` |
+| `icon`                 | `icon`                    | Define icon by its name. Name must be one of the existing icon: https://components.ducky.eco/?path=/story/component-svgicon--all-icons  Default: NULL | `string`  | `null`      |
+| `size`                 | `size`                    | Define the icon's size.  Allowed values: <value><unit>  Examples: - 1em - 42px  Default: 1em                                                          | `string`  | `'1em'`     |
+| `triggerButtonOnClick` | `trigger-button-on-click` | Allow the icon to trigger click on the closest parent button. Default: false                                                                          | `boolean` | `false`     |
 
 
 ## Dependencies

--- a/packages/component-library/src/components/plmg-svg-icon/test/plmg-svg-icon.spec.tsx
+++ b/packages/component-library/src/components/plmg-svg-icon/test/plmg-svg-icon.spec.tsx
@@ -1,26 +1,49 @@
-// import { newSpecPage } from '@stencil/core/testing';
-// import { SvgIcon } from '../plmg-svg-icon';
+import { newSpecPage } from '@stencil/core/testing';
+import { SvgIcon } from '../plmg-svg-icon';
 
 describe('plmg-svg-icon', () => {
-  // it('renders', async () => {
-  //   const page = await newSpecPage({
-  //     components: [SvgIcon],
-  //     html: `<plmg-svg-icon size="1em" icon="home"></plmg-svg-icon>`,
-  //   });
-  //
-  //   expect(page.root).toEqualHtml(`
-  //     <plmg-svg-icon icon="home" size="1em">
-  //       <mock:shadow-root>
-  //           <div style="height: 1em; width: 1em; font-size: 1em;">
-  //               <svg fill="currentColor" viewBox="0 0 24 24" id="home" height="1em" width="1em"><path d="m12 5.69 5 4.5V18h-2v-6H9v6H7v-7.81l5-4.5M12 3 2 12h3v8h6v-6h2v6h6v-8h3L12 3z"></path></svg>
-  //           </div>
-  //       </mock:shadow-root>
-  //     </plmg-svg-icon>
-  //   `);
-  // });
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [SvgIcon],
+      html: `<plmg-svg-icon icon="sample-icon"></plmg-svg-icon>`,
+    });
 
-  // TODO better tests like the one above
-  it('needs better tests', () => {
-    expect(true).toBeTruthy();
+    expect(page.root).toEqualHtml(`
+      <plmg-svg-icon icon="sample-icon">
+        <mock:shadow-root>
+          <div class="plmg-svg-icon" style="font-size: 1em; color: inherit;"></div>
+        </mock:shadow-root>
+      </plmg-svg-icon>
+    `);
+  });
+
+  it('renders with custom color', async () => {
+    const page = await newSpecPage({
+      components: [SvgIcon],
+      html: `<plmg-svg-icon icon="sample-icon" color="red"></plmg-svg-icon>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <plmg-svg-icon icon="sample-icon" color="red">
+        <mock:shadow-root>
+          <div class="plmg-svg-icon" style="font-size: 1em; color: red;"></div>
+        </mock:shadow-root>
+      </plmg-svg-icon>
+    `);
+  });
+
+  it('renders with custom size', async () => {
+    const page = await newSpecPage({
+      components: [SvgIcon],
+      html: `<plmg-svg-icon icon="sample-icon" size="2em"></plmg-svg-icon>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <plmg-svg-icon icon="sample-icon" size="2em">
+        <mock:shadow-root>
+          <div class="plmg-svg-icon" style="font-size: 2em; color: inherit;"></div>
+        </mock:shadow-root>
+      </plmg-svg-icon>
+    `);
   });
 });


### PR DESCRIPTION
<!-- List all User Stories / Bug / Task addressed in this PR. Add one line per Asana link. -->

Closes [BUG Plmg-Button - Icon stops button being clickable](https://app.asana.com/0/1186514044360546/1204976637079968/f)
### Summary of changes included in this PR

- Adds a prop to plmg-svg-icon called triggerButtonOnClick.
-  When triggerButtonOnClick is true, clicking on the icon triggers the click event of the closest parent button 
- This prop is used by plmg-button when an icon is provided so that clicking on the icon triggers the click on the parent not the icon
- Add some tests 

### Reviewer checklist:

- Tests for
  - accessibility
  - rendered HTML (spec)
- Storybook stories for all variants
- JSDoc documentation for component
- Update Example app (React, ...)

